### PR TITLE
#161255351 Fix JWT encoding

### DIFF
--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -46,13 +46,13 @@ class JWTAuthentication(BaseAuthentication):
         # token validity or a user not existing
 
         token = auth[1]
+        user = None
         try:
             payload = jwt.decode(token, SECRET_KEY)
-            email = payload['email']
+            pk = payload['id']
 
             user = User.objects.get(
-                email=email,
-                is_active=True
+                pk=pk
             )
         # Except cuustom errors while using the token
         except Exception as e:
@@ -72,11 +72,10 @@ class JWTAuthentication(BaseAuthentication):
     def encode_token(self, user_id):
         """
         This method gerate token by encoding registered user
-        email andress
+        email address
         """
         payload = {
             'id': user_id,
-            'iat': datetime.utcnow(),
-            'exp': datetime.utcnow() + timedelta(days=7)
+            'iat': datetime.utcnow()
         }
         return jwt.encode(payload, SECRET_KEY).decode('UTF-8')

--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -2,17 +2,19 @@
 JWT Configuration module
 """
 import jwt
-import json
+
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.http import HttpResponse
 
 from rest_framework import authentication, exceptions
-from rest_framework.authentication import get_authorization_header, BaseAuthentication
+from rest_framework.authentication import (
+    get_authorization_header,
+    BaseAuthentication)
 
 from .models import User
 from authors.settings import SECRET_KEY
-from datetime import datetime, timedelta
 
 
 class JWTAuthentication(BaseAuthentication):
@@ -32,7 +34,7 @@ class JWTAuthentication(BaseAuthentication):
         if not auth or auth[0].lower() != b'bearer':
             return None
 
-        # Check if the correct credemtials were passed in 'request' parameter
+        # Check if the correct credentials were passed in 'request' parameter
         if len(auth) == 1:
             msg = 'Invalid token header. No credentials provided.'
             raise exceptions.AuthenticationFailed(msg)
@@ -41,7 +43,7 @@ class JWTAuthentication(BaseAuthentication):
             msg = 'Invalid token header'
             raise exceptions.AuthenticationFailed(msg)
 
-        # Decode token sucessfully, else catch some errors;
+        # Decode token successfully, else catch some errors;
         # errors can be due to expired signature, in decoding
         # token validity or a user not existing
 
@@ -54,7 +56,7 @@ class JWTAuthentication(BaseAuthentication):
             user = User.objects.get(
                 pk=pk
             )
-        # Except cuustom errors while using the token
+        # Except custom errors while using the token
         except Exception as e:
             if e.__class__.__name__ == 'DecodeError':
                 raise exceptions.AuthenticationFailed('cannot decode token')

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -59,6 +59,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
 
 class LoginSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
     email = serializers.CharField(max_length=255)
     username = serializers.CharField(max_length=255, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
@@ -129,9 +130,10 @@ class LoginSerializer(serializers.Serializer):
         # This is the data that is passed to the `create` and `update` methods
         # that we will see later on.
         return {
+            'id': user.pk,
             'email': user.email,
             'username': user.username,
-            'token': JWTAuthentication.encode_token(self, user.email)
+            'token': JWTAuthentication.encode_token(self, user.pk)
         }
 
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -60,8 +60,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
 class LoginSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
-    email = serializers.CharField(max_length=255)
-    username = serializers.CharField(max_length=255, read_only=True)
+    email = serializers.CharField(max_length=50)
+    username = serializers.CharField(max_length=20, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
     token = serializers.CharField(read_only=True)
 
@@ -130,7 +130,6 @@ class LoginSerializer(serializers.Serializer):
         # This is the data that is passed to the `create` and `update` methods
         # that we will see later on.
         return {
-            'id': user.pk,
             'email': user.email,
             'username': user.username,
             'token': JWTAuthentication.encode_token(self, user.pk)


### PR DESCRIPTION
   #### What does this PR do?
* Fix JWT authentication to encode `user id` instead of `user email`
#### Description of Task to be completed?
* Encode user id with JWT
* Validate login credentials using the `id` of the logged in user
#### How should this be manually tested?
1. Clone the repo and checkout `bg_JWT_encode_id` branch
2. setup the database
3. set up the virtual environment
4. Run the `/api/users/` endpoint with JSON data to register a user
5. Run the `/api/users/login` endpoint with the credentials you registered with
6. You should see a `token` as one of the responses
7. enter the token in the authorization header in the format `Bearer token`
8. Try `GET` ing an authenticated route `/api/user/`
9. You should see the details of the logged in user in the response

#### Any background context you want to provide?
* Implementation of JWT is more secure compared to hashing or using sessions to transfer or store 
 user data

#### What are the relevant pivotal tracker stories?

* Users should receive a JWT on successful Registration- [#161255351](https://www.pivotaltracker.com/story/show/161255351)

#### Screenshots
##### The login endpoint on Postman
<img width="983" alt="screen shot 2018-11-06 at 11 11 22" src="https://user-images.githubusercontent.com/11288990/48050992-ca591a00-e1b4-11e8-9e80-f037b3a70c49.png">

##### Getting an authenticated route after putting the token in Auth header
<img width="978" alt="screen shot 2018-11-06 at 11 05 25" src="https://user-images.githubusercontent.com/11288990/48050807-1f486080-e1b4-11e8-9f3c-57f70010b504.png">



#### Questions
