### PR TITLE
#162752096 User should be able to comment and reply on article comments

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -235,17 +235,6 @@ class CommentSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
-    def get_author(self, obj):
-        try:
-            author = obj.author
-            profile = Profile.objects.get(user_id=author.id)
-            serializer = ProfileSerializer(profile)
-            return serializer.data
-        except Exception as e:
-            return {}
-        except Exception as e:
-            return {}
-
     def create(self, valid_input):
         """
         Create and return a new comment instance, given a valid_input

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -216,6 +216,7 @@ class CommentSerializer(serializers.ModelSerializer):
             'likes',
         )
 
+
     def get_author(self, obj):
         try:
             author = obj.author

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -197,7 +197,7 @@ class CommentSerializer(serializers.ModelSerializer):
     """
     This class creates the comments serializers
     """
-    author = serializers.SerializerMethodField()
+    author = UserSerializer(read_only=True)
     article = serializers.ReadOnlyField(source='article.title')
     thread = RecursiveSerializer(many=True, read_only=True)
     likes = serializers.SerializerMethodField(method_name='count_likes')
@@ -223,15 +223,6 @@ class CommentSerializer(serializers.ModelSerializer):
         instance.body = valid_input.get('body', instance.body)
         instance.save()
         return instance
-
-    def get_author(self, obj):
-        try:
-            author = obj.author
-            profile = Profile.objects.get(user_id=author.id)
-            serializer = ProfileSerializer(profile)
-            return serializer.data
-        except Exception as e:
-            return {}
 
     def create(self, valid_input):
         """
@@ -348,4 +339,3 @@ class TagSerializer(serializers.ModelSerializer):
 
     def to_representation(self, object):
         return object.tag
-        

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -226,6 +226,16 @@ class CommentSerializer(serializers.ModelSerializer):
             'likes',
         )
 
+    def get_author(self, obj):
+        try:
+            author = obj.author
+            profile = Profile.objects.get(user_id=author.id)
+            serializer = ProfileSerializer(profile)
+            return serializer.data
+        except Exception as e:
+            return {}
+
+
     def update(self, instance, valid_input, **kwargs):
         """
         Update and return a comment instance, given valid_input

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -226,6 +226,7 @@ class CommentSerializer(serializers.ModelSerializer):
             'likes',
         )
 
+
     def get_author(self, obj):
         try:
             author = obj.author

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -197,7 +197,7 @@ class CommentSerializer(serializers.ModelSerializer):
     """
     This class creates the comments serializers
     """
-    author = UserSerializer(read_only=True)
+    author = serializers.SerializerMethodField()
     article = serializers.ReadOnlyField(source='article.title')
     thread = RecursiveSerializer(many=True, read_only=True)
     likes = serializers.SerializerMethodField(method_name='count_likes')
@@ -217,6 +217,14 @@ class CommentSerializer(serializers.ModelSerializer):
         )
 
 
+    def update(self, instance, valid_input, **kwargs):
+        """
+        Update and return a comment instance, given valid_input
+        """
+        instance.body = valid_input.get('body', instance.body)
+        instance.save()
+        return instance
+
     def get_author(self, obj):
         try:
             author = obj.author
@@ -225,15 +233,6 @@ class CommentSerializer(serializers.ModelSerializer):
             return serializer.data
         except Exception as e:
             return {}
-
-
-    def update(self, instance, valid_input, **kwargs):
-        """
-        Update and return a comment instance, given valid_input
-        """
-        instance.body = valid_input.get('body', instance.body)
-        instance.save()
-        return instance
 
     def create(self, valid_input):
         """

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -207,7 +207,7 @@ class CommentSerializer(serializers.ModelSerializer):
     """
     This class creates the comments serializers
     """
-    author = serializers.SerializerMethodField()
+    author = UserSerializer(read_only=True)
     article = serializers.ReadOnlyField(source='article.title')
     thread = RecursiveSerializer(many=True, read_only=True)
     likes = serializers.SerializerMethodField(method_name='count_likes')
@@ -233,15 +233,6 @@ class CommentSerializer(serializers.ModelSerializer):
         instance.body = valid_input.get('body', instance.body)
         instance.save()
         return instance
-
-    def get_author(self, obj):
-        try:
-            author = obj.author
-            profile = Profile.objects.get(user_id=author.id)
-            serializer = ProfileSerializer(profile)
-            return serializer.data
-        except Exception as e:
-            return {}
 
     def create(self, valid_input):
         """

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -207,7 +207,7 @@ class CommentSerializer(serializers.ModelSerializer):
     """
     This class creates the comments serializers
     """
-    author = UserSerializer(read_only=True)
+    author = serializers.SerializerMethodField()
     article = serializers.ReadOnlyField(source='article.title')
     thread = RecursiveSerializer(many=True, read_only=True)
     likes = serializers.SerializerMethodField(method_name='count_likes')
@@ -227,6 +227,14 @@ class CommentSerializer(serializers.ModelSerializer):
         )
 
 
+    def update(self, instance, valid_input, **kwargs):
+        """
+        Update and return a comment instance, given valid_input
+        """
+        instance.body = valid_input.get('body', instance.body)
+        instance.save()
+        return instance
+
     def get_author(self, obj):
         try:
             author = obj.author
@@ -235,15 +243,6 @@ class CommentSerializer(serializers.ModelSerializer):
             return serializer.data
         except Exception as e:
             return {}
-
-
-    def update(self, instance, valid_input, **kwargs):
-        """
-        Update and return a comment instance, given valid_input
-        """
-        instance.body = valid_input.get('body', instance.body)
-        instance.save()
-        return instance
 
     def create(self, valid_input):
         """

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -216,6 +216,16 @@ class CommentSerializer(serializers.ModelSerializer):
             'likes',
         )
 
+    def get_author(self, obj):
+        try:
+            author = obj.author
+            profile = Profile.objects.get(user_id=author.id)
+            serializer = ProfileSerializer(profile)
+            return serializer.data
+        except Exception as e:
+            return {}
+
+
     def update(self, instance, valid_input, **kwargs):
         """
         Update and return a comment instance, given valid_input

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -207,7 +207,7 @@ class CommentSerializer(serializers.ModelSerializer):
     """
     This class creates the comments serializers
     """
-    author = serializers.SerializerMethodField()
+    author = UserSerializer(read_only=True)
     article = serializers.ReadOnlyField(source='article.title')
     thread = RecursiveSerializer(many=True, read_only=True)
     likes = serializers.SerializerMethodField(method_name='count_likes')
@@ -241,6 +241,8 @@ class CommentSerializer(serializers.ModelSerializer):
             profile = Profile.objects.get(user_id=author.id)
             serializer = ProfileSerializer(profile)
             return serializer.data
+        except Exception as e:
+            return {}
         except Exception as e:
             return {}
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -226,7 +226,6 @@ class CommentSerializer(serializers.ModelSerializer):
             'likes',
         )
 
-
     def update(self, instance, valid_input, **kwargs):
         """
         Update and return a comment instance, given valid_input

--- a/authors/apps/authentication/tests/test_auth.py
+++ b/authors/apps/authentication/tests/test_auth.py
@@ -12,11 +12,13 @@ class ViewTestCase(BaseTest):
             self.user_email_exists,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
     
     def test_register_user(self):
         """Test user signup capability."""
         response = self.register_user()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['username'], "zawi")
 
     def test_user_registration_username_exists(self):
         """Test user with that username already exists"""
@@ -26,6 +28,7 @@ class ViewTestCase(BaseTest):
             self.user_username_exists,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_user_registration_missing_fields(self):
         """Test user registers with missing fields"""
@@ -36,6 +39,7 @@ class ViewTestCase(BaseTest):
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertRaises(TypeError, response.data)
+        self.assertEqual(len(response.data['errors']), 3)
 
     def test_user_registration_missing_username_parameter(self):
         """Test user registers with missing username parameter"""
@@ -45,6 +49,7 @@ class ViewTestCase(BaseTest):
             self.user_missing_username_parameter,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_user_registration_missing_email_parameter(self):
         """Test user registers with missing email parameter"""
@@ -54,6 +59,7 @@ class ViewTestCase(BaseTest):
             self.user_missing_email_parameter,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_user_registration_short_password(self):
         """Test user registers with short password"""
@@ -62,7 +68,8 @@ class ViewTestCase(BaseTest):
             self.user_inputs_short_password,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    
+        self.assertEqual(len(response.data['errors']), 1)
+
     def test_user_registration_invalid_email(self):
         """Test user registers invalid email"""
 
@@ -71,12 +78,15 @@ class ViewTestCase(BaseTest):
             self.user_inputs_invalid_email,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
+
 
     def test_login_user(self):
         """Test the api has user login capability."""
         response = self.register_user()
         response = self.login_user()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['username'], "zawi")
 
     def test_login_user_wrong_password(self):
         """Test wrong login credentials."""
@@ -87,6 +97,7 @@ class ViewTestCase(BaseTest):
             format="json")
         self.assertEqual(json.loads(response.content)["errors"]["error"], ["Incorrect password."])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_login_user_non_existent(self):
         """Test if user does not exist"""
@@ -96,6 +107,7 @@ class ViewTestCase(BaseTest):
             self.user_does_not_exist,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_missing_password(self):
         """Test missing password on registration."""
@@ -105,6 +117,7 @@ class ViewTestCase(BaseTest):
             self.missing_password,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data['errors']), 1)
 
     def test_verify_email(self):
         '''Test verify email'''
@@ -115,3 +128,4 @@ class ViewTestCase(BaseTest):
         response = self.client.get(VERIFY_URL)
         self.assertEqual(json.loads(response.content), 'Email Confirmed Successfully')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, "Email Confirmed Successfully")

--- a/authors/apps/authentication/tests/test_auth.py
+++ b/authors/apps/authentication/tests/test_auth.py
@@ -35,6 +35,7 @@ class ViewTestCase(BaseTest):
             self.user_missing_fields,
             format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertRaises(TypeError, response.data)
 
     def test_user_registration_missing_username_parameter(self):
         """Test user registers with missing username parameter"""

--- a/authors/apps/notifications_app/tests/test_notifications.py
+++ b/authors/apps/notifications_app/tests/test_notifications.py
@@ -39,6 +39,9 @@ class UserNotificationsTestCase(BaseTest):
             self.MARK_AS_READ.format(first_notification),
             HTTP_AUTHORIZATION=self.token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            'Notification has been read',
+            json.loads(response.content)['message'])
 
     def test_get_all_read_notifications(self):
         """

--- a/authors/apps/notifications_app/tests/test_notifications.py
+++ b/authors/apps/notifications_app/tests/test_notifications.py
@@ -108,7 +108,7 @@ class UserNotificationsTestCase(BaseTest):
             self.ALL_NOTIFICATIONS,
             HTTP_AUTHORIZATION=self.token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # self.assertEqual('you are not subscribed to notifications', 
+        # self.assertEqual('you are not subscribed to notifications',
         # json.loads(response.content)['message'])
         response = self.client.post(
             self.SUBSCRIPTION,

--- a/authors/apps/notifications_app/tests/test_notifications.py
+++ b/authors/apps/notifications_app/tests/test_notifications.py
@@ -26,6 +26,17 @@ class UserNotificationsTestCase(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(3, len(json.loads(response.content)))
 
+    def test_get_all_notifications_unauth(self):
+        """
+        test get all user notifications
+        """
+        response = self.client.get(
+            self.ALL_NOTIFICATIONS)
+        message = json.loads(response.content.decode("utf-8"))['message']
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(message, 'you are not subscribed to notifications')
+
+
     def test_mark_notification_as_read(self):
         """
         test mark a notification as read


### PR DESCRIPTION
### What does this PR do?
- fixes the issue with posting authors of comments and replies

### Description of tasks to be completed?
- ensure the author of the comment is posted
- ensure the author of the reply is posted

### How can this be manually tested?
- clone the repo
- checkout `bg-comment-thread-162752096`
- create a virtual env with recommended  env settings
- setup database
- run migrations
- register and login a user
- post an article
- comment on the article posted
- reply on the comment

### Screenshots
#### Show comment author
<img width="1129" alt="screen shot 2018-12-19 at 16 32 52" src="https://user-images.githubusercontent.com/11288990/50225796-8ad83d00-03b2-11e9-8d03-ab056cd998c2.png">

#### Show reply author
<img width="1122" alt="screen shot 2018-12-19 at 16 33 09" src="https://user-images.githubusercontent.com/11288990/50225801-8f045a80-03b2-11e9-9427-f995bc4b325d.png">

### What are the relevant PT stories?

- User should be able to comment on an article - [Bug #162752096](https://www.pivotaltracker.com/story/show/162752096)