### PR TITLE
Bug #162723150) User should be able to filter by tags.

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -199,3 +199,10 @@ class Tag(TimeStamp):
 
     def __str__(self):
         return self.tag
+
+    @classmethod
+    def edit_tags(cls):
+        tags = set(Article.objects.values_list('tags', flat=True))
+        if None in tags:
+            tags.remove(None)
+        Tag.objects.exclude(pk__in=(tags)).delete()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -153,6 +153,7 @@ class ArticleSerializer(serializers.ModelSerializer):
             'description', instance.description)
         if tags:
             instance.tags.set(tags)
+            Tag.edit_tags()
         instance.images = validated_data.get('images', instance.images)
         instance.time_to_read = self.get_time_to_read(
             instance.body, instance.images)

--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -82,6 +82,15 @@ class ArticleTestCase(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(article_data["title"],
                       json.loads(response.content)["title"])
+        # test update tags
+        response = self.client.put(
+            self.TESTARTICLE, {"tagList": ["new tag"]}, HTTP_AUTHORIZATION=self.token, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("new tag",
+                      json.loads(response.content)["tagList"])
+        response2 = self.get_article_tags()
+        self.assertNotIn("math", json.loads(response2.content)["tags"])
+        
         # test non-author
         response = self.client.put(
             self.TESTARTICLE, article_data, HTTP_AUTHORIZATION=self.non_user_token, format="json")

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -146,6 +146,7 @@ class ArticlesView(ArticleMetaData, viewsets.ModelViewSet):
         if email != article.author:
             raise PermissionDenied
         article.delete()
+        Tag.edit_tags()
         return Response(dict(message="Article {} deleted successfully".format(slug)), status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
#### What does this PR do?
- Adds a method to delete tags without a relationship to articles on article delete and update
#### Description of bug:
- Tags without a relationship to articles should not be fetched
#### Relevant PR story
[User should be able to filter by tags](https://www.pivotaltracker.com/story/show/162723150)